### PR TITLE
Update to Swift 5.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 
 import PackageDescription
 
@@ -11,8 +11,7 @@ let package = Package(
         .watchOS(.v6)
     ],
     products: [
-        .library(name: "JWWCore", type: .static, targets: ["JWWCore"]),
-        .library(name: "JWWCoreDynamic", type: .dynamic, targets: ["JWWCore"])
+        .library(name: "JWWCore", targets: ["JWWCore"]),
     ],
     dependencies: [ ],
     targets: [


### PR DESCRIPTION
> The Swift Package Manager now builds package products and
targets as dynamic frameworks automatically, if doing so avoids
duplication of library code at runtime. (59931771) (FB7608638)

https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-release-notes